### PR TITLE
Update full control example to use limited access credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ use League\Flysystem\Filesystem;
 
 $credentials = new \Google_Auth_AssertionCredentials(
     '[your service account]',
-    [\Google_Service_Storage::DEVSTORAGE_FULL_CONTROL],
+    [\Google_Service_Storage::DEVSTORAGE_READ_WRITE],
     file_get_contents('[[path to the p12 key file]]'),
     '[[your secret]]'
 );


### PR DESCRIPTION
The Adapter itself only needs the `DEVSTORAGE_READ_WRITE` scope

Closes: #1