### PR TITLE
Allow both Version 1 and Version 2 of Google API Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	"require": {
 		"php": ">=5.4.0",
 		"league/flysystem": "~1.0",
-		"google/apiclient": "~1.1"
+		"google/apiclient": "~1.1|^2.0.0@RC"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.0",


### PR DESCRIPTION
It will default to the newer version (2.0.0RC and up).
If another composer dependency depends on version ~1.1,
the 1.1 branch will be used.

Closes: #5