### PR TITLE
Use get instead of has in getOptionsFromConfig

### DIFF
--- a/src/GoogleStorageAdapter.php
+++ b/src/GoogleStorageAdapter.php
@@ -76,13 +76,13 @@ class GoogleStorageAdapter extends AbstractAdapter
     {
         $options = [];
 
-        if ($config->has('visibility')) {
+        if ($config->get('visibility')) {
             $options['acl'] = $config->get('visibility') === AdapterInterface::VISIBILITY_PUBLIC ?
                 AdapterInterface::VISIBILITY_PUBLIC :
                 AdapterInterface::VISIBILITY_PRIVATE;
         }
 
-        if ($config->has('mimetype')) {
+        if ($config->get('mimetype')) {
             $options['mimetype'] = $config->get('mimetype');
         }
 


### PR DESCRIPTION
[getOptionsFromConfig](https://github.com/Superbalist/flysystem-google-storage/blob/master/src/GoogleStorageAdapter.php#L75) ignores any configuration that has been set directly on the Adapter's defaults.

In the current state using this example:
```
            'filesystem' => new Filesystem($cachedAdapter2, array(
                'visibility' => AdapterInterface::VISIBILITY_PUBLIC,
            ))
```
the "visibility" setting is ignored

For extra clarification have a look at [Config->has](https://github.com/thephpleague/flysystem/blob/master/src/Config.php#L51)